### PR TITLE
bugfix/redirect only active

### DIFF
--- a/app/api/endpoints/url.py
+++ b/app/api/endpoints/url.py
@@ -43,10 +43,16 @@ async def create_url(url: CreateUrlRequest) -> CreateUrlResponse:
 async def forward_to_url(url_key: str):
     url_repository = UrlRepository()
 
-    repository_response = await url_repository.get(url_key)
+    url = await url_repository.get(url_key)
 
-    if repository_response:
-        return repository_response.target_url
+    if url:
+        if url.is_active:
+            return url.target_url
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Requested key: '{url_key}' is not active.",
+            )
     else:
         raise HTTPException(
             status_code=404,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "url-shortener"
-version = "0.1.0"
+version = "0.1.1"
 description = "Url shortener API"
 authors = ["Algirdas Jauniskis <jauniskis.a@gmail.com>"]
 readme = "README.md"

--- a/tests/api/endpoints/test_url.py
+++ b/tests/api/endpoints/test_url.py
@@ -132,7 +132,7 @@ class TestUrl(IsolatedAsyncioTestCase):
         "app.api.endpoints.url.UrlRepository",
         new=UrlRepositoryOverride,
     )
-    async def test_forward_to_url__invalid_key__returns_message(self):
+    async def test_forward_to_url__invalid_key__returns_404(self):
         redirect_key = "invalid_redirect_url"
         actual = self.client.get(
             f"/api/url/{redirect_key}",
@@ -151,4 +151,29 @@ class TestUrl(IsolatedAsyncioTestCase):
         self.assertEqual(
             actual.status_code,
             404,
+        )
+
+    @patch(
+        "app.api.endpoints.url.UrlRepository",
+        new=UrlRepositoryOverride,
+    )
+    async def test_forward_to_url__disabled_key__returns_400(self):
+        redirect_key = "disabled_redirect_url"
+        actual = self.client.get(
+            f"/api/url/{redirect_key}",
+            follow_redirects=False,
+        )
+
+        expected = {
+            "detail": f"Requested key: '{redirect_key}' is not active.",
+        }
+
+        self.assertEqual(
+            actual.json(),
+            expected,
+        )
+
+        self.assertEqual(
+            actual.status_code,
+            400,
         )

--- a/tests/overrides.py
+++ b/tests/overrides.py
@@ -24,6 +24,13 @@ class UrlRepositoryOverride(UrlRepository):
                 secret_key="secret_key",
                 target_url=HttpUrl("https://google.com", scheme="https"),
             )
+        elif key == "disabled_redirect_url":
+            return Url(
+                key=key,
+                secret_key="secret_key",
+                target_url=HttpUrl("https://google.com", scheme="https"),
+                is_active=False,
+            )
         else:
             return None
 


### PR DESCRIPTION
Updating `/api/url/{redirect_key}` endpoint to redirect only active urls, otherwise return 400.
